### PR TITLE
Add an optional post-process callback to MeteorUserProcessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 * Added an optional post-process callback to MeteorUserProcessor (#38).
 * Moved message details to message_details context key (#37).
+* Fixed comment in Logger.log() describing the opposite of reality
 
 ### 0.1.14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### 0.1.15
 
+* Added an optional post-process callback to MeteorUserProcessor (#38).
 * Moved message details to message_details context key (#37).
 
 ### 0.1.14

--- a/src/Logger.js
+++ b/src/Logger.js
@@ -145,7 +145,7 @@ const Logger = class {
    * @param {Object} rawContext
    *   (Optional). An object complementing the message.
    * @param {Boolean} cooked
-   *   (Optional). Is the context already reduced ?
+   *   (Optional). Apply processors to context before sending. Default == true.
    *
    * @returns {void}
    *

--- a/src/Processors/MeteorUserProcessor.js
+++ b/src/Processors/MeteorUserProcessor.js
@@ -5,7 +5,7 @@ import ProcessorBase from "./ProcessorBase";
 import stack from "callsite";
 
 /**
- * MeteorUserProcessor adds Meteor server-side account information to log events.
+ * MeteorUserProcessor adds Meteor account information to log events.
  *
  * @extends ProcessorBase
  */
@@ -13,8 +13,10 @@ const MeteorUserProcessor = class extends ProcessorBase {
   /**
    * @param {Meteor} meteor
    *   The Meteor service.
+   * @param {Function} postProcess
+   *   Optional. A post-process callback to be invoked after the main process().
    */
-  constructor(meteor = Meteor) {
+  constructor(meteor = Meteor, postProcess = null) {
     super();
     if (!meteor) {
       throw new Error("Meteor processor is only meant for Meteor code.");
@@ -35,7 +37,9 @@ const MeteorUserProcessor = class extends ProcessorBase {
     else {
       throw new Error("This version of the meteor user processor only supports client and server platforms.");
     }
+
     this.meteor = meteor;
+    this.postProcess = postProcess;
     this.userCache = {};
   }
 
@@ -157,12 +161,17 @@ const MeteorUserProcessor = class extends ProcessorBase {
     }
 
     // Overwrite any previous userId information in context.
-    const result = Object.assign({}, context, {
+    let result = Object.assign({}, context, {
       meteor: {
         platform: this.platform,
         user
       }
     });
+
+    if (this.postProcess) {
+      result = this.postProcess(result);
+    }
+
     return result;
   }
 };

--- a/test/unit/meteorUserProcessorTest.js
+++ b/test/unit/meteorUserProcessorTest.js
@@ -1,0 +1,48 @@
+const chai = require("chai");
+const assert = chai.assert;
+
+import MeteorUserProcessor from "../../src/Processors/MeteorUserProcessor";
+
+function testMeteorUserProcessor() {
+  const mockMeteor = { isServer: true };
+  const mockAccountsPackage = { "accounts-base": { AccountsServer: true } };
+
+  const postProcessorDelete = data => {
+    let result = Object.assign({}, data);
+    delete result.meteor.user.services;
+    return result;
+  };
+
+  const forcedUserId = 42;
+  const postProcessorUpdate = data => {
+    let result = Object.assign({}, data);
+    result.meteor.user = forcedUserId;
+    return result;
+  };
+
+  it("should accept a collection name", function () {
+    const data = { anything: "goes" };
+    global.Package = mockAccountsPackage;
+    const processorRaw = new MeteorUserProcessor(mockMeteor);
+    const processorDeletor = new MeteorUserProcessor(mockMeteor, postProcessorDelete);
+    const processorUpdater = new MeteorUserProcessor(mockMeteor, postProcessorUpdate);
+    delete(global.PACKAGE);
+
+    assert.instanceOf(processorRaw, MeteorUserProcessor);
+    const resultRaw = processorRaw.process(data);
+    assert.isDefined(resultRaw.meteor.user.services);
+
+    assert.instanceOf(processorDeletor, MeteorUserProcessor);
+    const resultDeleted = processorDeletor.process(data);
+    assert.isUndefined(resultDeleted.meteor.user.services);
+
+    assert.instanceOf(processorUpdater, MeteorUserProcessor);
+    const resultUpdated = processorUpdater.process(data);
+    assert.equal(resultUpdated.meteor.user, forcedUserId);
+  });
+
+}
+
+export {
+  testMeteorUserProcessor
+};

--- a/test/unit/test.js
+++ b/test/unit/test.js
@@ -4,6 +4,7 @@
 
 import { testImmutableContext, testMessageContext, testObjectifyContext } from './logContextTest';
 import { testLogLevels } from './logLevelsTest';
+import { testMeteorUserProcessor } from './meteorUserProcessorTest';
 import { testMongoDbSender } from './mongodbSenderTest';
 import { testSerializeDeepObject } from './serializationTest';
 import { testStrategyConstruction } from './strategyTest';
@@ -26,4 +27,5 @@ describe("Unit", () => {
     describe("serializeDeepObject", testSerializeDeepObject);
   });
   describe("MongoDbSender", testMongoDbSender);
+  describe("MeteorUserProcessor", testMeteorUserProcessor);
 });


### PR DESCRIPTION
* Issue #38  support an optional process = null argument in the MeteorUserProcessor constructor