### PR TITLE
BrowserProcessor's 'performance' entry is always {}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Upcoming
 
 * ProcessorBase, SenderBase, StrategyBase are now exported to make custom versions easier
+* BrowserProcessor now provides actual window.performance.memory values
 * BrowserProcessor no longer provides obsolete "product" key
 * Quality control: Travis CI, CodeClimate, and Bithound integration
 

--- a/src/Processors/BrowserProcessor.js
+++ b/src/Processors/BrowserProcessor.js
@@ -70,7 +70,7 @@ const BrowserProcessor = class extends ProcessorBase {
           totalJSHeapSize: this.window.performance.memory.totalJSHeapSize,
           usedJSHeapSize: this.window.performance.memory.usedJSHeapSize,
         },
-      } : 
+      } :
       {};
 
     return result;

--- a/src/Processors/BrowserProcessor.js
+++ b/src/Processors/BrowserProcessor.js
@@ -54,7 +54,7 @@ const BrowserProcessor = class extends ProcessorBase {
     };
 
     // Ensure a browser key exists, using the contents from context if available.
-    let result = Object.assign({ browser: {} }, context);
+    let result = Object.assign({ browser: { performance: this.window.performance } }, context);
 
     // Overwrite existing browser keys in context, keeping non-overwritten ones.
     for (const key in browserDefaults) {
@@ -63,8 +63,8 @@ const BrowserProcessor = class extends ProcessorBase {
       }
     }
 
-    result.browser.performance = (this.window.performance && this.window.performance.memory)
-      ? window.performance.memory
+    result.browser.performance.memory = (this.window.performance && this.window.performance.memory)
+      ? this.window.performance.memory
       : {};
 
     return result;

--- a/src/Processors/BrowserProcessor.js
+++ b/src/Processors/BrowserProcessor.js
@@ -63,9 +63,15 @@ const BrowserProcessor = class extends ProcessorBase {
       }
     }
 
-    result.browser.performance.memory = (this.window.performance && this.window.performance.memory)
-      ? this.window.performance.memory
-      : {};
+    result.browser.performance = (this.window.performance && this.window.performance.memory) ?
+      {
+        memory: {
+          jsHeapSizeLimit: this.window.performance.memory.jsHeapSizeLimit,
+          totalJSHeapSize: this.window.performance.memory.totalJSHeapSize,
+          usedJSHeapSize: this.window.performance.memory.usedJSHeapSize,
+        },
+      } : 
+      {};
 
     return result;
   }

--- a/test/unit/browserProcessorTest.js
+++ b/test/unit/browserProcessorTest.js
@@ -1,6 +1,18 @@
 import BrowserProcessor from "../../src/Processors/BrowserProcessor";
 
 function testBrowserProcessor() {
+  class Performance {
+    constructor(values = {}) {
+      for (const key of Object.keys(values)) {
+        this[key] = values[key];
+      }
+    }
+
+    toJSON() {
+      return { memory: {} };
+    }
+  }
+
   let initialContext;
   let navigator = {};
   let window = {};
@@ -8,7 +20,7 @@ function testBrowserProcessor() {
   beforeEach(() => {
     initialContext = { anything: "goes" };
     navigator = {};
-    window = {};
+    window = { performance: new Performance() };
   });
 
   test("should fail outside the browser", () => {
@@ -37,6 +49,39 @@ function testBrowserProcessor() {
     expect(actual).toHaveProperty("browser.platform");
     expect(actual).toHaveProperty("browser.userAgent");
     expect(actual).not.toHaveProperty("browser.product");
+  });
+
+  /* This test hand-builds the MemoryInfo object in window.Performance, because
+   * that class is not defined outside Chrome.
+   */
+  test("should serialize performance.memory correctly", () => {
+    const keys = [
+      "jsHeapSizeLimit",
+      "totalJSHeapSize",
+      "usedJSHeapSize",
+    ];
+    const win = Object.assign({}, { performance: new Performance({ memory: {} }) });
+    const processor = new BrowserProcessor(navigator, win);
+    expect(processor).toBeInstanceOf(BrowserProcessor);
+
+    // Ensure sub-keys are actually present in the Performance object.
+    const processed = processor.process(initialContext);
+    expect(processed).toHaveProperty("browser");
+    expect(processed).toHaveProperty("browser.performance");
+    expect(processed).toHaveProperty("browser.performance.memory");
+    for (const key of keys) {
+      expect(processed).toHaveProperty(`browser.performance.memory.${key}`);
+    }
+
+    // Ensure they are available after serialization by parsing the serialized result.
+    const string = JSON.stringify(processed);
+    const actual = JSON.parse(string);
+    expect(actual).toHaveProperty("browser");
+    expect(actual).toHaveProperty("browser.performance");
+    expect(actual).toHaveProperty("browser.performance.memory");
+    for (const key of keys) {
+      expect(actual).toHaveProperty(`browser.performance.memory.${key}`);
+    }
   });
 }
 

--- a/test/unit/browserProcessorTest.js
+++ b/test/unit/browserProcessorTest.js
@@ -1,5 +1,8 @@
 import BrowserProcessor from "../../src/Processors/BrowserProcessor";
 
+/* This test hand-builds the MemoryInfo object in window.Performance, because
+ * that class is not defined outside Chrome.
+ */
 function testBrowserProcessor() {
   class Performance {
     constructor(values = {}) {
@@ -51,16 +54,17 @@ function testBrowserProcessor() {
     expect(actual).not.toHaveProperty("browser.product");
   });
 
-  /* This test hand-builds the MemoryInfo object in window.Performance, because
-   * that class is not defined outside Chrome.
-   */
   test("should serialize performance.memory correctly", () => {
     const keys = [
       "jsHeapSizeLimit",
       "totalJSHeapSize",
       "usedJSHeapSize",
     ];
-    const win = Object.assign({}, { performance: new Performance({ memory: {} }) });
+    const win = Object.assign({}, { performance: new Performance({ memory: {
+      jsHeapSizeLimit: 1,
+      totalJSHeapSize: 2,
+      usedJSHeapSize: 3,
+    } }) });
     const processor = new BrowserProcessor(navigator, win);
     expect(processor).toBeInstanceOf(BrowserProcessor);
 


### PR DESCRIPTION
window.performance.memory is an object of class MemoryInfo, which doesn't serialize to JSON : `JSON.stringify(window.performance.memory)` is `"{}"`

We need to explicitly include the three properties.