### PR TITLE
Dev mode for console sender

### DIFF
--- a/src/Senders/ConsoleSender.js
+++ b/src/Senders/ConsoleSender.js
@@ -13,8 +13,8 @@ const ConsoleSender = class extends SenderBase {
   /**
    * @constructor
    *
-   * @param {String} devMode
-   *   Optional: Print only short logs, omitting the context
+   * @param {Boolean} devMode
+   *   Optional: Print only short logs, omitting the context. Defaults to false.
    */
   constructor(devMode = false) {
     super();
@@ -42,7 +42,8 @@ const ConsoleSender = class extends SenderBase {
 
     if (this.devMode) {
       method(LogLevel.Names[level], message);
-    } else {
+    }
+    else {
       method(LogLevel.Names[level], message, context);
     }
   }

--- a/src/Senders/ConsoleSender.js
+++ b/src/Senders/ConsoleSender.js
@@ -10,11 +10,19 @@ import SenderBase from "./SenderBase";
  * @extends SenderBase
  */
 const ConsoleSender = class extends SenderBase {
-  constructor() {
+  /**
+   * @constructor
+   *
+   * @param {String} devMode
+   *   Optional: Print only short logs, omitting the context
+   */
+  constructor(devMode = false) {
     super();
     if (!console) {
       throw new Error("Console sender needs a console object.");
     }
+
+    this.devMode = devMode;
   }
 
   /** @inheritDoc */
@@ -31,7 +39,12 @@ const ConsoleSender = class extends SenderBase {
     ];
 
     const method = methods[level].bind(console);
-    method(LogLevel.Names[level], message, context);
+
+    if (this.devMode) {
+      method(LogLevel.Names[level], message);
+    } else {
+      method(LogLevel.Names[level], message, context);
+    }
   }
 };
 


### PR DESCRIPTION
Addressing issue https://github.com/fgm/filog/issues/42 , I'm suggesting this change to the `ConsoleSender` to enable nice and short, yet informative, console messages when developing.

I followed the convention of other senders in how to handle function arguments, but I'd personally prefer named args.

Then, this:

```js
const shortSender = new ConsoleSender(true);
```

would become this:

```js
const shortSender = new ConsoleSender({ devMode: true });
```

...which I think is a lot better and self-documenting. Should I make the change?